### PR TITLE
Fix weather icon fallback

### DIFF
--- a/src/app/components/HourlyForecastCard.test.tsx
+++ b/src/app/components/HourlyForecastCard.test.tsx
@@ -1,12 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import HourlyForecastCard from "./HourlyForecastCard";
 
-jest.mock("./WeatherConditionIcons", () => ({
-  weatherConditionIcons: {
-    "clear-day": (props: any) => (
-      <div data-testid="weather-icon">Clear Day Icon</div>
-    ),
-  },
+jest.mock("rocketicons/wi", () => ({
+  WiSnow: () => <svg data-testid="weather-icon" />,
+  WiRain: () => <svg data-testid="weather-icon" />,
+  WiFog: () => <svg data-testid="weather-icon" />,
+  WiWindy: () => <svg data-testid="weather-icon" />,
+  WiCloudy: () => <svg data-testid="weather-icon" />,
+  WiDayCloudy: () => <svg data-testid="weather-icon" />,
+  WiNightAltPartlyCloudy: () => <svg data-testid="weather-icon" />,
+  WiDaySunny: () => <div data-testid="weather-icon">Clear Day Icon</div>,
+  WiNightClear: () => <svg data-testid="weather-icon" />,
 }));
 
 describe("HourlyForecastCard component", () => {

--- a/src/app/components/TenDayForecastCard.test.tsx
+++ b/src/app/components/TenDayForecastCard.test.tsx
@@ -11,16 +11,23 @@ jest.mock("../util/dayFromDate", () => ({
   default: (dateStr: string) => `Day-${dateStr}`,
 }));
 
-jest.mock("./WeatherConditionIcons", () => ({
-  weatherConditionIcons: {
-    "clear-day": (props: any) => <svg data-testid="weather-icon" {...props} />,
-    cloudy: (props: any) => <svg data-testid="weather-icon" {...props} />,
-    snow: (props: any) => <svg data-testid="fallback-icon" {...props} />,
-  },
-  isWeatherIconKey: (key: string) => ["clear-day", "cloudy"].includes(key),
+jest.mock("rocketicons/wi", () => ({
+  WiSnow: () => <svg data-testid="weather-icon" />,
+  WiRain: () => <svg data-testid="weather-icon" />,
+  WiFog: () => <svg data-testid="weather-icon" />,
+  WiWindy: () => <svg data-testid="weather-icon" />,
+  WiCloudy: () => <svg data-testid="weather-icon" />,
+  WiDayCloudy: () => <svg data-testid="weather-icon" />,
+  WiNightAltPartlyCloudy: () => <svg data-testid="weather-icon" />,
+  WiDaySunny: () => <svg data-testid="weather-icon" />,
+  WiNightClear: () => <svg data-testid="weather-icon" />,
 }));
 
-const mockDays: WeatherDataDay[] = [
+jest.mock("rocketicons/rx", () => ({
+  RxValueNone: () => <svg data-testid="weather-fallback-icon" />,
+}));
+
+const sampleDays: WeatherDataDay[] = [
   {
     datetime: "2025-03-28",
     tempmax: 15.8,
@@ -69,19 +76,19 @@ const mockDays: WeatherDataDay[] = [
 
 describe("TenDayForecastCard", () => {
   test("renders the title and calendar icon", () => {
-    render(<TenDayForecastCard days={mockDays} />);
+    render(<TenDayForecastCard days={sampleDays} />);
     expect(screen.getByText("10-Day Forecast")).toBeInTheDocument();
     expect(screen.getByTestId("calendar-icon")).toBeInTheDocument();
   });
 
   test("renders one forecast row per day", () => {
-    render(<TenDayForecastCard days={mockDays} />);
+    render(<TenDayForecastCard days={sampleDays} />);
     const rows = screen.getAllByText(/Day-2025/);
     expect(rows).toHaveLength(2);
   });
 
   test("displays the correct date and rounded temperatures", () => {
-    render(<TenDayForecastCard days={mockDays} />);
+    render(<TenDayForecastCard days={sampleDays} />);
     expect(screen.getByText("Day-2025-03-28")).toBeInTheDocument();
     expect(screen.getByText("5°")).toBeInTheDocument();
     expect(screen.getByText("16°")).toBeInTheDocument();
@@ -92,8 +99,15 @@ describe("TenDayForecastCard", () => {
   });
 
   test("renders weather icons for each day", () => {
-    render(<TenDayForecastCard days={mockDays} />);
+    render(<TenDayForecastCard days={sampleDays} />);
     const icons = screen.getAllByTestId("weather-icon");
     expect(icons).toHaveLength(2);
+  });
+
+  test("renders fallback weather icons for invalid weather icon string", () => {
+    render(
+      <TenDayForecastCard days={[{ ...sampleDays[0], icon: "INVALID" }]} />
+    );
+    screen.getByTestId("weather-fallback-icon");
   });
 });

--- a/src/app/components/TenDayForecastCard.tsx
+++ b/src/app/components/TenDayForecastCard.tsx
@@ -3,7 +3,11 @@ import { roundNumber } from "../util/math";
 import WeatherCard from "./WeatherCard";
 import { WeatherDataDay } from "../visual-crossing/visual-crossing-api";
 import dayFromDate from "../util/dayFromDate";
-import { weatherConditionIcons, WeatherIconKey } from "./WeatherConditionIcons";
+import {
+  isWeatherIconKey,
+  weatherConditionIcons,
+} from "./WeatherConditionIcons";
+import { RxValueNone } from "rocketicons/rx";
 
 interface TenDayForecastCardProps {
   days: WeatherDataDay[];
@@ -17,7 +21,9 @@ export default function TenDayForecastCard(props: TenDayForecastCardProps) {
     >
       <div>
         {props.days.map((day) => {
-          const WeatherIcon = weatherConditionIcons[day.icon as WeatherIconKey];
+          const WeatherIcon = isWeatherIconKey(day.icon)
+            ? weatherConditionIcons[day.icon]
+            : RxValueNone;
 
           return (
             <div key={day.datetime} className="flex justify-between text-sm">


### PR DESCRIPTION
- add a type guard to the weatherIcon lookup
- mock the icons coming from rocketicons, instead of mocking our util function