### PR TITLE
SearchBar - query on clicks and enters

### DIFF
--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -119,7 +119,7 @@ export default function SearchBar(props: SearchBarProps) {
       <div
         ref={searchDivRef}
         tabIndex={-1}
-        onFocus={(event) => setSearchHasFocus(true)}
+        onFocus={() => setSearchHasFocus(true)}
         onBlur={(event) =>
           !event.relatedTarget?.contains(event.target) &&
           setSearchHasFocus(false)

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -143,9 +143,8 @@ export default function SearchBar(props: SearchBarProps) {
             onKeyDown={handleSearchKeyDown}
           />
           <div
-            tabIndex={0}
             data-testid="search-button"
-            className="inline-block"
+            className="inline-block outline-0"
             onClick={() => runQuery(searchBoxRef.current?.value)}
           >
             <HiSearch className="size-8" />

--- a/src/app/components/SearchBar.tsx
+++ b/src/app/components/SearchBar.tsx
@@ -75,6 +75,13 @@ export default function SearchBar(props: SearchBarProps) {
     setAutoSuggestionSelected(-1);
   };
 
+  const runQuery = (query: string | undefined) => {
+    searchDivRef.current?.focus();
+    searchDivRef.current?.blur();
+    updateAutoSuggestions(query || "");
+    router.push(`/?city=${encodeURIComponent(query || "")}`);
+  };
+
   const handleSearchKeyDown = ((event) => {
     switch (event.key) {
       case "ArrowDown":
@@ -86,6 +93,9 @@ export default function SearchBar(props: SearchBarProps) {
       case "ArrowUp":
         setAutoSuggestionSelected(Math.max(autoSuggestionSelected - 1, 0));
         event.preventDefault();
+        break;
+      case "Enter":
+        runQuery(searchBoxRef.current?.value);
         break;
       default:
         break;
@@ -109,7 +119,7 @@ export default function SearchBar(props: SearchBarProps) {
       <div
         ref={searchDivRef}
         tabIndex={-1}
-        onFocus={() => setSearchHasFocus(true)}
+        onFocus={(event) => setSearchHasFocus(true)}
         onBlur={(event) =>
           !event.relatedTarget?.contains(event.target) &&
           setSearchHasFocus(false)
@@ -132,15 +142,14 @@ export default function SearchBar(props: SearchBarProps) {
             onChange={(event) => updateAutoSuggestions(event.target.value)}
             onKeyDown={handleSearchKeyDown}
           />
-          <HiSearch
+          <div
+            tabIndex={0}
             data-testid="search-button"
-            className="inline-block size-8"
-            onClick={() =>
-              router.push(
-                `/?city=${encodeURIComponent(searchBoxRef.current?.value || "")}`
-              )
-            }
-          />
+            className="inline-block"
+            onClick={() => runQuery(searchBoxRef.current?.value)}
+          >
+            <HiSearch className="size-8" />
+          </div>
         </div>
 
         {autoSuggestVisible ? (
@@ -158,7 +167,14 @@ export default function SearchBar(props: SearchBarProps) {
                     "px-2 py-1"
                   )}
                   key={cityData.name}
-                  onClick={() => setAutoSuggestionSelected(index)}
+                  onClick={() => {
+                    setAutoSuggestionSelected(index);
+                    runQuery(
+                      createAutoSuggestQueryFromCityDataRow(
+                        autoSuggestions[index]
+                      )
+                    );
+                  }}
                 >
                   {createAutoSuggestQueryFromCityDataRow(cityData)}
                 </div>


### PR DESCRIPTION
- trigger the query event from
  - hitting `Enter` while input field is focused
  - clicking the search button
  - clicking on an auto suggestion
- remove focus from the `SearchBar` after triggering a query
- refactor the button to use a wrapper div